### PR TITLE
use correct variable

### DIFF
--- a/synthx/method.py
+++ b/synthx/method.py
@@ -181,7 +181,7 @@ def placebo_test(
             )
             return None
 
-    results = Parallel(n_jobs=-1)(
+    results = Parallel(n_jobs=n_jobs)(
         delayed(process_placebo)(test_unit_placebo) for test_unit_placebo in tqdm(control_units)
     )
 
@@ -222,7 +222,7 @@ def sensitivity_check(
             )
             .then(pl.col(dataset.y_column) * uplift)
             .otherwise(pl.col(dataset.y_column))
-            .alias('y')
+            .alias(dataset.y_column)
         )
 
         dataset_sensitivity = sx.Dataset(


### PR DESCRIPTION
# Description

**What is the context? (Why these changes are required?)**
- fix hard-coded 'y' to y_column (#42 )
- n_jobs argument was not used (#43 )

**What has been changed?**
fix
